### PR TITLE
Fix initial release errors

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,6 +15,7 @@ permissions: read-all
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    environment: github-pages
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,10 +2,10 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Fill a REDCap Project with synthetic data
+title: REDCap Filler - an R package that fills a REDCap Project with synthetic data
 message:
-  If you use this software, please cite it using the
-  metadata from this file.
+  If you use this software, please cite it with the metadata
+  in CITATION.cff or https://doi.org/10.5281/zenodo.15635725
 type: software
 authors:
   - family-names: Chase
@@ -38,16 +38,20 @@ repository-code:
 url:
   https://ctsit.github.io/redcapfiller/
 abstract:
-  Fill a REDCap Project with synthetic data based on the project 
-  design and a minimal set of inputs.
+  REDCap Filler is an R package that can fill a REDCap project
+  with synthetic data using the project design and a minimal
+  set of paramaters as input. It uses the REDCap API to read
+  a project's design and write the synthetic data back to the
+  project.
 keywords:
   - redcap
+  - redcap api
   - clinical science
   - data management
   - synthetic data
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.15634676
+    value: 10.5281/zenodo.15635725
 license: Apache-2.0
 version: 0.1.0
 date-released: '2025-06-10'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# Apache 2.0 License
+
 Copyright 2025 University of Florida
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # redcapfiller 0.1.0 (released 2025-06-10)
+* Initial release (@pbchase, @saipavan10-git, @ljwoodley)
 * Works on **classic projects** and **longitudinal projects**.
 * Uses the REDCap API to read the project design and write the generated data.
 * Fills categorical fields (providing a uniform random distribution).
@@ -10,4 +11,3 @@
 * Does not violate basic data constraints defined in the data dictionary (e.g., validation types, ranges where applicable).
 * Populates specified events in longitudinal projects.
 * Fills a specified number of records.
-* Authors: @pbchase, @saipavan10-git, @ljwoodley

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 [REDCap Filler](https://github.com/ctsit/redcapfiller)
 =======
 
-REDCap Filler provides a testing and development service to users of Vanderbilt University's [REDCap](https://projectredcap.org/). It generates and loads synthetic test data into a REDCap project, using the project's design to guide test data generation. This data-driven process allows rapid data creation with minimal effort. This provides a low-cost way to test many of the project features. It provides test data as input for reporting and other downstream processes.
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15635725.svg)](https://doi.org/10.5281/zenodo.15635725)
+[![R-CMD-check](https://github.com/ctsit/redcapfiller/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ctsit/redcapfiller/actions/workflows/R-CMD-check.yaml)
+
+REDCap Filler provides a testing and development service to users of Vanderbilt University's [REDCap](https://projectredcap.org/). It generates and loads synthetic test data into a REDCap project, using the project's design to guide test data generation. This data-driven process allows rapid data creation with minimal effort. This provides a low-cost way to test many of the project features. It creates test data as input for reporting and other downstream processes.
 
 ### Installation
 
-The redcapfiller package is only available as source code on GitHub. Install it from github inside R or RStudio using the `remotes` package:
+The redcapfiller package is only available as source code on GitHub. Install it from GitHub inside R or RStudio using the `remotes` package:
 
 ```r
 install.packages("remotes") # Run this line if the 'remotes' package hasn't been installed already.
@@ -14,16 +17,16 @@ remotes::install_github("ctsit/redcapfiller")
 
 ### Using REDCap Filler
 
-See https://ctsit.github.io/redcapfiller/articles/getting_started.html to learn how to use redcapfiller.
+See [Getting started with redcapfiller](https://ctsit.github.io/redcapfiller/articles/getting_started.html) to learn how to use redcapfiller.
 
 ### Limitations
 
-REDCap Filler does not yet understand all the dimensions of a modern REDCap project. It can fill the categorical fields. It can fill unvalidated text field and the text validation types date, datetime, email, integer, number, phone, and zipcode. It ignores all other field types and validation types and will not attempt to fill them. Filler can fill classic and longitudinal projects, but not if they have repeating forms, repeating events, or randomization enabled. It does not honor form display logic and ignores all fields governed by branching logic.
+REDCap Filler does not yet understand all the dimensions of a modern REDCap project. It can fill the categorical fields. It can fill unvalidated text fields and the text validation types date, datetime, email, integer, number, phone, and zip code. It ignores all other field types and validation types and will not attempt to fill them. Filler can fill classic and longitudinal projects, but not if they have repeating forms, repeating events, or randomization enabled. It does not honor form display logic and ignores all fields governed by branching logic.
 
 *   Works on **classic projects** and **longitudinal projects**.
 *   Uses the REDCap API to read the project design and write the synthetic data.
 *   Fills categorical fields (providing a uniform random distribution).
-*   Fills unvalidated text fields and fields with common text validation types: date, datetime, email, integer, number, phone, and zipcode.
+*   Fills unvalidated text fields and fields with common text validation types: date, datetime, email, integer, number, phone, and zip code.
     *   Provides random-normal distributions for numeric and date fields.
     *   Uses "Lorem ipsum" text for non-validated text fields. 
     *   Injects simple default randomness where practicable for other types.
@@ -44,10 +47,10 @@ REDCap Filler does not yet understand all the dimensions of a modern REDCap proj
 
 This project aims to populate complex REDCap projects using the project design. If the REDCap API exposes a design dimension, we plan to use that to guide how the Filler populates projects. Yet, that will take some time to develop fully. This is the proposed timeline of features:
 
-1.  Complete support for any text validation types missing currently.
+1.  Complete support for any text validation types currently missing.
 2.  Add support for **repeating events** and **repeating forms**.
 3.  Skip randomization fields to allow support for projects with **randomization**.
-3.  Allow user specification of non-uniform distributions for categorical fields and non-default distributions for ranged fields.
+4.  Allow users to specify non-uniform distributions for categorical fields and non-default distributions for range fields.
 4.  Allow configuration of inter-record and intra-record date offsets.
 5.  Add support for evaluating **Branching Logic**.
 6.  Add support for evaluating **Form Display Logic**.
@@ -57,9 +60,3 @@ This project aims to populate complex REDCap projects using the project design. 
 We encourage input and collaboration.  If you're familiar with GitHub and R packages, submit a [pull request](https://github.com/ctsit/redcapfiller/pulls). If you'd like to report a bug or suggest, please create a GitHub [issue](https://github.com/ctsit/redcapfiller/issues); issues are usually a good place to ask public questions, too. However, email Philip if you prefer an offline dialog (<pbc@ufl.edu>).
 
 We'd like to thank the REDCap Community for their advice and contributions to the design of REDCap Filler.
-
-### Build status
-
-<!-- badges: start -->
-[![R-CMD-check](https://github.com/ctsit/redcapfiller/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ctsit/redcapfiller/actions/workflows/R-CMD-check.yaml)
-<!-- badges: end -->


### PR DESCRIPTION
Add environment to pkgdown.yaml.
Update CITATION.cff for better presentation at Zenodo. Fix DOI in CITATION.cff.
Add title to LICENSE.md.
Reformat NEWS Entry.
Add DOI badge to README.
Move status badge to top in README.
Add label 'Getting started with redcapfiller' for article. Fix grammar and wording.